### PR TITLE
products pushstate

### DIFF
--- a/blocks/load-template/load-template.js
+++ b/blocks/load-template/load-template.js
@@ -1,0 +1,11 @@
+import { loadPage } from '../../scripts/scripts.js';
+
+export default async function decorate(block) {
+  const template = block.querySelector(':scope > div > div:nth-of-type(2)').textContent || '..';
+  const parent = await fetch(new URL(`${template}/${window.location.pathname.split('/').slice(-2, -1)[0]}.plain.html`, window.location.href));
+  window.contents = document.body.innerHTML;
+  const newbody = await parent.text();
+  const main = document.querySelector('main');
+  main.innerHTML = newbody;
+  await loadPage(document);
+}

--- a/blocks/products/products.js
+++ b/blocks/products/products.js
@@ -107,6 +107,7 @@ export default async function decorate(block) {
 
       picture.append(img);
       a.append(picture);
+      decoratePictures(a);
       carousel.append(a);
       return a;
     }));

--- a/blocks/products/products.js
+++ b/blocks/products/products.js
@@ -109,10 +109,31 @@ export default async function decorate(block) {
       a.append(picture);
       decoratePictures(a);
       carousel.append(a);
+
+      if (window.location.href !== path) {
+        // stash that content
+        const div = document.createElement('div');
+        div.className = 'product';
+        div.innerHTML = doc.body.innerHTML;
+        div.dataset.path = path;
+        decoratePictures(div);
+        products.append(div);
+      }
+
+      a.onclick = (e) => {
+        e.preventDefault();
+        window.history.pushState({ product: a.id }, '', a.href);
+        selectProduct(block, a.id, products);
+      };
+
       return a;
     }));
 
   block.append(carousel);
+
+  window.onpopstate = ({ state }) => {
+    selectProduct(block, state.product, products);
+  };
 
   const productInfo = document.createElement('div');
   productInfo.className = 'products-info';

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -204,7 +204,7 @@ function decorateBlocks($main) {
  * @param {string} blockName name of the block
  * @param {any} content two dimensional array or string or object of content
  */
-function buildBlock(blockName, content) {
+export function buildBlock(blockName, content) {
   const table = Array.isArray(content) ? content : [[content]];
   const blockEl = document.createElement('div');
   // build image block nested div structure
@@ -219,6 +219,7 @@ function buildBlock(blockName, content) {
           if (typeof val === 'string') {
             colEl.innerHTML += val;
           } else {
+            console.log('appending', val);
             colEl.appendChild(val);
           }
         }
@@ -267,6 +268,7 @@ export async function loadBlock(block, eager = false) {
   if (!(block.getAttribute('data-block-status') === 'loading' || block.getAttribute('data-block-status') === 'loaded')) {
     block.setAttribute('data-block-status', 'loading');
     const blockName = block.getAttribute('data-block-name');
+    console.log('loading block', blockName, block);
     try {
       const cssLoaded = new Promise((resolve) => {
         loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`, resolve);
@@ -580,6 +582,16 @@ function loadFooter(footer) {
   }
 }
 
+async function addLoadTemplateBlock(main) {
+  if (main.querySelector('div.nutrition-facts')
+  && main.querySelector('div.ingredients')
+  && !main.querySelector('div.load-template')) {
+    const loadTemplateBlock = buildBlock('load-template', [['template', '..']]);
+    main.append(loadTemplateBlock);
+    decorateBlock(loadTemplateBlock);
+  }
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -587,6 +599,7 @@ function loadFooter(footer) {
 function buildAutoBlocks(main) {
   try {
     buildHeroBlock(main);
+    addLoadTemplateBlock(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -502,7 +502,7 @@ async function waitForLCP() {
 /**
  * Decorates the page.
  */
-async function loadPage(doc) {
+export async function loadPage(doc) {
   // eslint-disable-next-line no-use-before-define
   await loadEager(doc);
   // eslint-disable-next-line no-use-before-define
@@ -572,9 +572,12 @@ function loadHeader(header) {
 
 function loadFooter(footer) {
   const footerBlock = buildBlock('footer', '');
-  footer.append(footerBlock);
-  decorateBlock(footerBlock);
-  loadBlock(footerBlock);
+  // do not load footer twice
+  if (!footer.children.length) {
+    footer.append(footerBlock);
+    decorateBlock(footerBlock);
+    loadBlock(footerBlock);
+  }
 }
 
 /**


### PR DESCRIPTION
Improvement on #3 by reintroducing on-page pseudo-navigation, albeit with `window.history.pushState` to keep the back button working. The resulting URL can be copied as before.

- refactor(products): clicking on a product will now open the product page
- fix(products): decorate injected pictures
- feat(products): use window.history.pushstate to navigate between product pages


Test pages:
- https://products-pushstate--cocacola-journey--hlxsites.hlx3.page/brands/coca-cola1/coca-cola-vanilla (blocks in content)
- https://products-pushstate--cocacola-journey--hlxsites.hlx3.page/brands/coca-cola/coca-cola-vanilla (autoblocks)

click on a product, then another one, then try the back button.