### PR TITLE
fix: add bubbles to image grid overlay

### DIFF
--- a/blocks/images-grid/images-grid.css
+++ b/blocks/images-grid/images-grid.css
@@ -53,6 +53,27 @@ main .images-grid .overlay {
   line-height: 1.1;
 }
 
+main .images-grid .overlay p:first-child {
+  position: relative;
+}
+
+main .images-grid .overlay p:first-child:before {
+  content: '';
+  -webkit-mask-box-image: url(/icons/bubble.svg);
+  -webkit-mask-image: url(/icons/bubble.svg);
+  -webkit-mask-size: 11px 40px;
+  -webkit-mask-repeat: no-repeat;
+  vertical-align: text-bottom;
+  display: block;
+  position: absolute;
+  height: 40px;
+  width: 11px;
+  padding: 0;
+  bottom: -.8rem;
+  left: -1.6rem;
+  background: #fff;
+}
+
 main .images-grid .row.right .overlay {
   border: 1px solid red;
 }


### PR DESCRIPTION
before: https://main--cocacola-journey--hlxsites.hlx.live/
after: https://index-bubbles--cocacola-journey--hlxsites.hlx.live/

<img width="314" alt="Screen Shot 2022-02-04 at 9 42 55 AM" src="https://user-images.githubusercontent.com/43383503/152567927-f3e7a2cd-23f6-4adf-9749-c9a20d649c80.png">

